### PR TITLE
Use GITHUB_OUTPUT envvar instead of set-output command as the latter is deprecated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           changed_dirs=$(git diff --name-only origin/${{ github.base_ref }} | grep '.go$' | xargs -I {} dirname {} | uniq | awk '{print "\"" $0 "\""}' | jq -R -s -c 'split("\n")[:-1]')
           echo "Changed directories: $changed_dirs"
-          echo "::set-output name=matrix::$changed_dirs"
+          echo "matrix=$changed_dirs" >> $GITHUB_OUTPUT
 
   test:
     needs: diff


### PR DESCRIPTION
Signed-off-by: Arun <arun@arun.blog>
