### PR TITLE
206. Reverse Linked List

### DIFF
--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {}
+

--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -1,4 +1,10 @@
 package main
 
-func main() {}
+type ListNode struct {
+	Val  int
+	Next *ListNode
+}
 
+func ReverseList(head *ListNode) *ListNode {
+	return nil
+}

--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -6,12 +6,13 @@ type ListNode struct {
 }
 
 func ReverseList(head *ListNode) *ListNode {
-	var node *ListNode
-	for temp := head; temp != nil; temp = temp.Next {
-		node = &ListNode{
-			Val:  temp.Val,
-			Next: node,
-		}
+	var prev *ListNode
+	current := head
+	for current != nil {
+		next := current.Next
+		current.Next = prev
+		prev = current
+		current = next
 	}
-	return node
+	return prev
 }

--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -6,5 +6,13 @@ type ListNode struct {
 }
 
 func ReverseList(head *ListNode) *ListNode {
-	return nil
+	var managed []*ListNode
+	for head != nil {
+		managed = append(managed, head)
+		head = head.Next
+	}
+	i, j := 0, len(managed)-1
+	for i < j {
+
+	}
 }

--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -6,13 +6,13 @@ type ListNode struct {
 }
 
 func ReverseList(head *ListNode) *ListNode {
-	var managed []*ListNode
-	for head != nil {
-		managed = append(managed, head)
-		head = head.Next
+	var prev *ListNode
+	current := head
+	for current != nil {
+		next := current.Next
+		current.Next = prev
+		prev = current
+		current = next
 	}
-	i, j := 0, len(managed)-1
-	for i < j {
-
-	}
+	return prev
 }

--- a/src/206-reverse-linked-list/main.go
+++ b/src/206-reverse-linked-list/main.go
@@ -6,13 +6,12 @@ type ListNode struct {
 }
 
 func ReverseList(head *ListNode) *ListNode {
-	var prev *ListNode
-	current := head
-	for current != nil {
-		next := current.Next
-		current.Next = prev
-		prev = current
-		current = next
+	var node *ListNode
+	for temp := head; temp != nil; temp = temp.Next {
+		node = &ListNode{
+			Val:  temp.Val,
+			Next: node,
+		}
 	}
-	return prev
+	return node
 }

--- a/src/206-reverse-linked-list/main_test.go
+++ b/src/206-reverse-linked-list/main_test.go
@@ -1,0 +1,6 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {}
+

--- a/src/206-reverse-linked-list/main_test.go
+++ b/src/206-reverse-linked-list/main_test.go
@@ -1,31 +1,35 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 )
+
+func isEqual(a, b *ListNode) bool {
+	for a != nil && b != nil {
+		if a.Val != b.Val {
+			return false
+		}
+		a = a.Next
+		b = b.Next
+	}
+	return a == nil && b == nil
+}
 
 func TestReverseList(t *testing.T) {
 	tests := map[string]struct {
 		input *ListNode
-		want  []int
+		want  *ListNode
 	}{
-		"reverse 5 elements": {&ListNode{1, &ListNode{2, &ListNode{3, &ListNode{4, &ListNode{5, nil}}}}}, []int{5, 4, 3, 2, 1}},
-		"reverse 2 elements": {&ListNode{1, &ListNode{2, nil}}, []int{2, 1}},
-		"reverse empty list": {nil, []int{}},
+		"reverse 5 elements": {&ListNode{1, &ListNode{2, &ListNode{3, &ListNode{4, &ListNode{5, nil}}}}}, &ListNode{5, &ListNode{4, &ListNode{3, &ListNode{2, &ListNode{1, nil}}}}}},
+		"reverse 2 elements": {&ListNode{1, &ListNode{2, nil}}, &ListNode{2, &ListNode{1, nil}}},
+		"reverse empty list": {nil, nil},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotList := ReverseList(tt.input)
-			var got []int
-			for gotList != nil {
-				got = append(got, gotList.Val)
-				gotList = gotList.Next
-			}
-
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("%s: got %v, want %v", name, got, tt.want)
+			got := ReverseList(tt.input)
+			if !isEqual(got, tt.want) {
+				t.Errorf("%s: lists are not equal", name)
 			}
 		})
 	}

--- a/src/206-reverse-linked-list/main_test.go
+++ b/src/206-reverse-linked-list/main_test.go
@@ -1,6 +1,32 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-func TestMain(t *testing.T) {}
+func TestReverseList(t *testing.T) {
+	tests := map[string]struct {
+		input *ListNode
+		want  []int
+	}{
+		"reverse 5 elements": {&ListNode{1, &ListNode{2, &ListNode{3, &ListNode{4, &ListNode{5, nil}}}}}, []int{5, 4, 3, 2, 1}},
+		"reverse 2 elements": {&ListNode{1, &ListNode{2, nil}}, []int{2, 1}},
+		"reverse empty list": {nil, []int{}},
+	}
 
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotList := ReverseList(tt.input)
+			var got []int
+			for gotList != nil {
+				got = append(got, gotList.Val)
+				gotList = gotList.Next
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("%s: got %v, want %v", name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Setup problem folder
- Setup test cases
- Update tests to avoid converting to []int and natively use ListNode
- Halfway through but give up because preparing an additional storage in the form of a managed slice is not efficient, should explore an in-place reversal
- In-place reversal by updating the pointers to point to the previous nodes
- Another approach involving creating a new list but is O(n) complexity and not memory efficient compared to the previous approach
- Revert "Another approach involving creating a new list but is O(n) complexity and not memory efficient compared to the previous approach"
