### PR TITLE
88. Merge Sorted Array

### DIFF
--- a/src/88-merge-sorted-array/main.go
+++ b/src/88-merge-sorted-array/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {}
+

--- a/src/88-merge-sorted-array/main.go
+++ b/src/88-merge-sorted-array/main.go
@@ -1,4 +1,5 @@
 package main
 
-func main() {}
+func merge(nums1 []int, m int, nums2 []int, n int) {
 
+}

--- a/src/88-merge-sorted-array/main.go
+++ b/src/88-merge-sorted-array/main.go
@@ -1,12 +1,15 @@
 package main
 
-import "sort"
-
 func merge(nums1 []int, m int, nums2 []int, n int) {
-	if n > 0 {
-		for i := 0; i < len(nums2); i++ {
-			nums1[m+i] = nums2[i]
+	i1, i2, mi := m-1, n-1, m+n-1
+	for i2 >= 0 {
+		if i1 >= 0 && nums1[i1] > nums2[i2] {
+			nums1[mi] = nums1[i1]
+			i1--
+		} else {
+			nums1[mi] = nums2[i2]
+			i2--
 		}
+		mi--
 	}
-	sort.Ints(nums1)
 }

--- a/src/88-merge-sorted-array/main.go
+++ b/src/88-merge-sorted-array/main.go
@@ -1,5 +1,12 @@
 package main
 
-func merge(nums1 []int, m int, nums2 []int, n int) {
+import "sort"
 
+func merge(nums1 []int, m int, nums2 []int, n int) {
+	if n > 0 {
+		for i := 0; i < len(nums2); i++ {
+			nums1[m+i] = nums2[i]
+		}
+	}
+	sort.Ints(nums1)
 }

--- a/src/88-merge-sorted-array/main_test.go
+++ b/src/88-merge-sorted-array/main_test.go
@@ -1,0 +1,6 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {}
+

--- a/src/88-merge-sorted-array/main_test.go
+++ b/src/88-merge-sorted-array/main_test.go
@@ -1,6 +1,26 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
-func TestMain(t *testing.T) {}
-
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		nums1 []int
+		m     int
+		nums2 []int
+		n     int
+		want  []int
+	}{
+		{[]int{1, 2, 3, 0, 0, 0}, 3, []int{2, 5, 6}, 3, []int{1, 2, 2, 3, 5, 6}},
+		{[]int{1}, 1, []int{}, 0, []int{1}},
+		{[]int{0}, 0, []int{1}, 1, []int{1}},
+	}
+	for _, tt := range tests {
+		merge(tt.nums1, tt.m, tt.nums2, tt.n)
+		if !reflect.DeepEqual(tt.nums1, tt.want) {
+			t.Errorf("merge(%v, %d, %v, %d) got %v, want %v", tt.nums1, tt.m, tt.nums2, tt.n, tt.nums1, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
- Setup problem folder
- Setup test cases
- Place nums2 values into the last indices marked as 0 on nums1, and then sort
- Improve merge efficiency in linear time without requiring a full sort after the merge as in previous approach
