### PR TITLE
1897. Redistribute Characters To Make All Strings Equal

### DIFF
--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {}
+

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
@@ -1,5 +1,31 @@
 package main
 
+import "strings"
+
 func makeEqual(words []string) bool {
+	hm := make(map[string]int)
+	count := 0
+	for _, word := range words {
+		characters := strings.Split(word, "")
+		count += len(characters)
+		for _, char := range characters {
+			hm[char]++
+		}
+	}
+	if count%len(words) == 0 && areCharCountsEqual(hm) {
+		return true
+	}
+	return false
+}
+
+func areCharCountsEqual(hm map[string]int) bool {
+	var prevCount int
+	for _, count := range hm {
+		if prevCount == 0 {
+			prevCount = count
+		} else if prevCount != count {
+			return false
+		}
+	}
 	return true
 }

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
@@ -1,4 +1,5 @@
 package main
 
-func main() {}
-
+func makeEqual(words []string) bool {
+	return true
+}

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main.go
@@ -1,29 +1,14 @@
 package main
 
-import "strings"
-
 func makeEqual(words []string) bool {
-	hm := make(map[string]int)
-	count := 0
+	hm := make(map[rune]int)
 	for _, word := range words {
-		characters := strings.Split(word, "")
-		count += len(characters)
-		for _, char := range characters {
+		for _, char := range word {
 			hm[char]++
 		}
 	}
-	if count%len(words) == 0 && areCharCountsEqual(hm) {
-		return true
-	}
-	return false
-}
-
-func areCharCountsEqual(hm map[string]int) bool {
-	var prevCount int
 	for _, count := range hm {
-		if prevCount == 0 {
-			prevCount = count
-		} else if prevCount != count {
+		if count%len(words) != 0 {
 			return false
 		}
 	}

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
@@ -1,0 +1,6 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {}
+

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
@@ -9,6 +9,7 @@ func TestMakeEqual(t *testing.T) {
 	}{
 		{[]string{"abc", "aabc", "bc"}, true},
 		{[]string{"ab", "a"}, false},
+		{[]string{"b", "a"}, false},
 	}
 	for _, tt := range tests {
 		got := makeEqual(tt.words)

--- a/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
+++ b/src/1897-redistribute-characters-to-make-all-strings-equal/main_test.go
@@ -2,5 +2,18 @@ package main
 
 import "testing"
 
-func TestMain(t *testing.T) {}
-
+func TestMakeEqual(t *testing.T) {
+	tests := []struct {
+		words []string
+		want  bool
+	}{
+		{[]string{"abc", "aabc", "bc"}, true},
+		{[]string{"ab", "a"}, false},
+	}
+	for _, tt := range tests {
+		got := makeEqual(tt.words)
+		if got != tt.want {
+			t.Errorf("makeEqual(%v) = %v, want %v", tt.words, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
- Setup problem folder
- Setup test cases
- Compare if all characters are of the same count, and if the total number of characters neatly divides by the length of words slice
- Add failing test case
- Solve by ensuring that each character's total count is divisible by the number of words, so that those characters can be equally placed in each word
